### PR TITLE
Refactor agent prompt helpers to use constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class CustomNewsAgent extends ChatAgent {
   constructor(dependencies: ChatAgentDependencies) {
     super(dependencies, 'CustomNewsAgent', [
-      agentPersonality().human,
-      agentTone().fun,
-      agentFormat().discordNews,
-      agentLanguage().french,
+      agentPersonality.human,
+      agentTone.fun,
+      agentFormat.discordNews,
+      agentLanguage.french,
     ]);
   }
 

--- a/src/adapters/outbound/agents/ai-news.agent.ts
+++ b/src/adapters/outbound/agents/ai-news.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class AINewsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'AINewsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordNews,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordNews,
+            agentLanguage.french,
         ]);
     }
 

--- a/src/adapters/outbound/agents/crypto-news.agent.ts
+++ b/src/adapters/outbound/agents/crypto-news.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class CryptoNewsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'CryptoNewsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordNews,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordNews,
+            agentLanguage.french,
         ]);
     }
 

--- a/src/adapters/outbound/agents/development-news.agent.ts
+++ b/src/adapters/outbound/agents/development-news.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class DevelopmentNewsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'DevelopmentNewsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordNews,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordNews,
+            agentLanguage.french,
         ]);
     }
 

--- a/src/adapters/outbound/agents/finance-news.agent.ts
+++ b/src/adapters/outbound/agents/finance-news.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class FinanceNewsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'FinanceNewsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordNews,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordNews,
+            agentLanguage.french,
         ]);
     }
 

--- a/src/adapters/outbound/agents/prompts/agent-format.ts
+++ b/src/adapters/outbound/agents/prompts/agent-format.ts
@@ -1,7 +1,7 @@
 import { discordEventsFormat } from './formats/discord-events-format.js';
 import { discordNewsFormat } from './formats/discord-news-format.js';
 
-export const agentFormat = () => ({
+export const agentFormat = {
     discordEvents: discordEventsFormat,
     discordNews: discordNewsFormat,
-});
+};

--- a/src/adapters/outbound/agents/prompts/agent-language.ts
+++ b/src/adapters/outbound/agents/prompts/agent-language.ts
@@ -1,5 +1,5 @@
 import { frenchLanguage } from './languages/french.js';
 
-export const agentLanguage = () => ({
+export const agentLanguage = {
     french: frenchLanguage,
-});
+};

--- a/src/adapters/outbound/agents/prompts/agent-personality.ts
+++ b/src/adapters/outbound/agents/prompts/agent-personality.ts
@@ -1,5 +1,5 @@
 import { humanPersonality } from './personalities/human-personality.js';
 
-export const agentPersonality = () => ({
+export const agentPersonality = {
     human: humanPersonality,
-});
+};

--- a/src/adapters/outbound/agents/prompts/agent-tone.ts
+++ b/src/adapters/outbound/agents/prompts/agent-tone.ts
@@ -1,7 +1,7 @@
 import { funTone } from './tones/fun-tone.js';
 import { professionalTone } from './tones/professional-tone.js';
 
-export const agentTone = () => ({
+export const agentTone = {
     fun: funTone,
     professional: professionalTone,
-});
+};

--- a/src/adapters/outbound/agents/space-events.agent.ts
+++ b/src/adapters/outbound/agents/space-events.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class SpaceEventsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'SpaceEventsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordEvents,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordEvents,
+            agentLanguage.french,
         ]);
     }
 

--- a/src/adapters/outbound/agents/technology-events.agent.ts
+++ b/src/adapters/outbound/agents/technology-events.agent.ts
@@ -10,10 +10,10 @@ import { createAnimatorPrompt } from './prompts/animator.js';
 export class TechnologyEventsAgent extends ChatAgent {
     constructor(dependencies: ChatAgentDependencies) {
         super(dependencies, 'TechnologyEventsAgent', [
-            agentPersonality().human,
-            agentTone().fun,
-            agentFormat().discordEvents,
-            agentLanguage().french,
+            agentPersonality.human,
+            agentTone.fun,
+            agentFormat.discordEvents,
+            agentLanguage.french,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- expose agent-format, agent-language, agent-personality and agent-tone as constant objects
- update all agents and docs to use the constant fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c608630508333ac737e830bb5bc88